### PR TITLE
support all parameter type when adding request_id

### DIFF
--- a/src/LogRequests.php
+++ b/src/LogRequests.php
@@ -3,6 +3,7 @@
 namespace ASamir\InDbPerformanceMonitor;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\UploadedFile;
 
 class LogRequests extends Model {
 
@@ -54,6 +55,9 @@ class LogRequests extends Model {
 
         $neglict = config('inDbPerformanceMonitor.IN_DB_MONITOR_NEGLICT_PARAMS_CONTAIN');
         foreach ($data as $k => $v)
+            if($v instanceof UploadedFile){
+                $data[$k] = '%_UploadedFile_%';
+            }
             foreach ($neglict as $n)
                 if (strpos(trim(strtolower($k)), trim(strtolower($n))) !== false)
                     $data[$k] = '%_HIDDEN_%';

--- a/src/LogRequests.php
+++ b/src/LogRequests.php
@@ -34,7 +34,8 @@ class LogRequests extends Model {
         // Store IP info.
         LogIPs::saveIPInfo(request()->ip());
 
-        request()->request->add(['__asamir_request_id' => $req->id]);
+        // Use replace method to support all parameter type (json, query, form-data)
+        request()->replace(array_merge(request()->all(),['__asamir_request_id' => $req->id]));
 
         // Log queries
         LogQueries::inDbLogQueries();


### PR DESCRIPTION
This package cannot log queries for request with GET method because of the code below:

`request()->request->add(['__asamir_request_id' => $req->id]);`

It only adds request_id to post-data ($_POST) which will not work for GET method.

I've replaced with this code so it will work for any method
`request()->replace(array_merge(request()->all(),['__asamir_request_id' => $req->id]));`
